### PR TITLE
fix: should not raise a warn when OCP labels are not informed

### DIFF
--- a/pkg/validation/openshift.go
+++ b/pkg/validation/openshift.go
@@ -268,8 +268,6 @@ func checkOCPLabel(checks OpenShiftOperatorChecks) OpenShiftOperatorChecks {
 			checks.errs = append(checks.errs, fmt.Errorf(deprecateOcpLabelMsg1_22,
 				checks.deprecateAPIsMsg,
 				ocpLabel))
-		} else {
-			checks.warns = append(checks.warns, fmt.Errorf("unable to find %s configuration", ocpLabel))
 		}
 	}
 

--- a/pkg/validation/openshift_test.go
+++ b/pkg/validation/openshift_test.go
@@ -228,17 +228,9 @@ func Test_checkOCPLabelsWithHasDeprecatedAPIs(t *testing.T) {
 			},
 		},
 		{
-			name:        "should warn when the OCP label is not found",
-			wantError:   false,
-			wantWarning: true,
-			args: args{
-				indexPath: "./testdata/dockerfile/bundle_without_label.Dockerfile",
-			},
-		},
-		{
 			name:        "should fail when the the index path is an invalid path",
 			wantError:   true,
-			wantWarning: true,
+			wantWarning: false,
 			args: args{
 				indexPath: "./testdata/dockerfile/invalid",
 			},


### PR DESCRIPTION
**Description**
Not all Operator bundles will have the bundle that is not a mandatory field so we should not warn